### PR TITLE
Generate generic comment to satisfy `#[deny(missing_docs)]` on struct type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ pub fn derive_field_names_as_array(
 
   let result = quote! {
     impl #impl_generics #name #type_generics #where_clause {
+      #[doc=concat!("Generated array of field names for `", stringify!(#name #type_generics), "`.")]
       #vis const FIELD_NAMES_AS_ARRAY: &'static [&'static str] =
         &[#field_names];
     }


### PR DESCRIPTION
Found your crate super useful and doing precisely what I needed, not more. It only tripped me up when enabling `#![deny(missing_docs)]` on the library for the pre-publish cleanup.

Since it is such a trivial change I did not open an issue first, hope that's ok.