### PR TITLE
Feature: add `rename` field attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ listing the field names of a struct.
          * [Rename all](#rename-all)
       * [Field Attributes](#field-attributes)
          * [Skip](#skip)
+         * [Rename](#rename)
 <!--te-->
 
 ## Usage
@@ -131,6 +132,24 @@ struct Foo {
 }
 
 assert_eq!(Foo::FIELD_NAMES_AS_SLICE, ["bar", "baz"]);
+```
+
+#### Rename
+
+The `rename` attribute renames the field in the generated constant.
+
+```rust
+use struct_field_names_as_array::FieldNamesAsArray;
+
+#[derive(FieldNamesAsArray)]
+struct Foo {
+    bar: String,
+    baz: String,
+    #[field_names_as_array(rename = "foo")]
+    bat: String,
+}
+
+assert_eq!(Foo::FIELD_NAMES_AS_ARRAY, ["bar", "baz", "foo"]);
 ```
 
 [serde_rename_all]: https://serde.rs/container-attrs.html#rename_all

--- a/struct-field-names-as-array-derive/src/attrs.rs
+++ b/struct-field-names-as-array-derive/src/attrs.rs
@@ -60,6 +60,7 @@ impl ParseAttributes for ContainerAttributes {
 
 pub struct FieldAttributes {
     skip: bool,
+    rename: Option<String>,
 }
 
 impl FieldAttributes {
@@ -68,13 +69,17 @@ impl FieldAttributes {
             return None;
         }
 
+        if let Some(rename) = &self.rename {
+            return Some(rename.to_owned());
+        }
+
         Some(field.to_owned())
     }
 }
 
 impl ParseAttributes for FieldAttributes {
     fn default(_attribute: &'static str) -> Self {
-        Self { skip: false }
+        Self { skip: false, rename: None }
     }
 
     fn parse_attribute(&mut self, m: ParseNestedMeta) -> Result<()> {
@@ -84,6 +89,11 @@ impl ParseAttributes for FieldAttributes {
 
         if m.path.is_ident("skip") {
             self.skip = true;
+            return Ok(());
+        }
+
+        if m.path.is_ident("rename") {
+            self.rename = Some(m.value()?.parse::<LitStr>()?.value());
             return Ok(());
         }
 

--- a/struct-field-names-as-array/tests/tests.rs
+++ b/struct-field-names-as-array/tests/tests.rs
@@ -26,6 +26,7 @@ struct TestSkip {
     #[field_names_as_slice(skip)]
     c: String,
 }
+
 #[derive(FieldNamesAsArray, FieldNamesAsSlice)]
 struct TestRename {
     a: String,

--- a/struct-field-names-as-array/tests/tests.rs
+++ b/struct-field-names-as-array/tests/tests.rs
@@ -35,7 +35,6 @@ struct TestRename {
     c: String,
 }
 
-
 #[test]
 fn test_struct() {
     assert_eq!(Test::FIELD_NAMES_AS_ARRAY, ["f1", "f2", "f3", "f4"]);

--- a/struct-field-names-as-array/tests/tests.rs
+++ b/struct-field-names-as-array/tests/tests.rs
@@ -26,6 +26,15 @@ struct TestSkip {
     #[field_names_as_slice(skip)]
     c: String,
 }
+#[derive(FieldNamesAsArray, FieldNamesAsSlice)]
+struct TestRename {
+    a: String,
+    b: String,
+    #[field_names_as_array(rename = "last_option")]
+    #[field_names_as_slice(rename = "last_option")]
+    c: String,
+}
+
 
 #[test]
 fn test_struct() {
@@ -49,4 +58,10 @@ fn test_generics_struct() {
 fn test_skip() {
     assert_eq!(TestSkip::FIELD_NAMES_AS_ARRAY, ["a", "b"]);
     assert_eq!(TestSkip::FIELD_NAMES_AS_SLICE, ["a", "b"]);
+}
+
+#[test]
+fn test_rename() {
+    assert_eq!(TestRename::FIELD_NAMES_AS_ARRAY, ["a", "b", "last_option"]);
+    assert_eq!(TestRename::FIELD_NAMES_AS_SLICE, ["a", "b", "last_option"]);
 }


### PR DESCRIPTION
Hi, Thanks for this great crate!

I added the `rename` field attribute so you can rename one field to the value you want, like with [serde(rename)](https://serde.rs/field-attrs.html#rename).

---
My use case for this is that I use structs for API queries using serde `rename` to serialize into camelCase but keeping snake_case for the struct names.

example 
```rust

#[derive(Deserialize, Serialize, Clone, Debug, FieldNamesAsArray)]
struct UserView {
	#[serde(rename = "userID")]
	#[field_names_as_array(rename = "userID")]
	pub user_id: u64,
	#[serde(rename = "userName")]
	#[field_names_as_array(rename = "userName")]
	pub user_name: String,
	pub followers: u64,
}

fn get_user_view(user_id: u64) -> Result<UserView> {
	let fields = UserView::FIELD_NAMES_AS_ARRAY;

	let view = client.user.get(&fields)?;
	// ^ This will generate a query with the
	// following format https://example.org/user/id?include_fields=userID,userName,followers

	Ok(view)
}
